### PR TITLE
Use Sonatype's repository for core.async

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,10 @@
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.clojure/clojurescript "0.0-1835"]
                  [org.clojure/core.match "0.2.0-rc2"]
-                 [core.async "0.1.0-SNAPSHOT"]]
+                 [org.clojure/core.async "0.1.0-SNAPSHOT"]]
+
+  :repositories {"sonatype-oss-public"
+                 "https://oss.sonatype.org/content/groups/public"}
 
   :plugins [[lein-cljsbuild "0.3.2"]]
 


### PR DESCRIPTION
Avoids the need to install `core.async` locally.
