### PR TITLE
Mouse example broken

### DIFF
--- a/src/async_test/mouse/core.cljs
+++ b/src/async_test/mouse/core.cljs
@@ -20,5 +20,5 @@
 
 (go
   (while true
-    (handler (alts! [mc kc]) )))
+    (handler (alts! (map :chan [mc kc])) )))
 


### PR DESCRIPTION
This fixes the mouse example for me on chrome develop channel.
