### PR TITLE
Rewrite autocomplete

### DIFF
--- a/src/async_test/autocomplete/core.cljs
+++ b/src/async_test/autocomplete/core.cljs
@@ -6,79 +6,44 @@
             [async-test.utils.helpers
              :refer [event-chan by-id copy-chan set-class throttle
                      clear-class jsonp-chan set-html now multiplex
-                     after-last map-chan filter-chan fan-in debounce]])
+                     after-last map-chan filter-chan fan-in debounce
+                     interval-chan uniq-chan timeout-chan throt monitor
+                     trans-chan]])
   (:require-macros [cljs.core.async.macros :as m :refer [go]]
                    [async-test.utils.macros :refer [go-loop]]))
-
-(def IGNORE #{98 16 37 38 39 40 18 20})
 
 (def base-url
   "http://en.wikipedia.org/w/api.php?action=opensearch&format=json&search=")
 
-(defn show-results [r]
-  (let [rs (by-id "completions")
-        _  (clear-class rs)
-        xs (nth r 1)]
-    (->> (for [x xs] (str "<li>" x "</li>"))
-      (apply str)
-      (set-html rs))))
+(defn show-results [el r]
+  (clear-class el "")
+  (condp = r
+    :empty
+    (set-html el "")
+    :keep
+    nil
+    (->> (for [x (nth r 1)]
+           (str "<li>" x "</li>"))
+         (apply str)
+         (set-html el))))
 
-(defn no-input [c el]
-  (->> c
-    (map-chan #(do % (.-value el)))
-    (filter-chan string/blank?)))
+(defn completion-chan [prefix]
+  (go
+   (if (string/blank? prefix)
+     :empty
+     (or (<! (timeout-chan 500 (jsonp-chan (str base-url prefix))))
+         :keep))))
 
-(defn autocompleter*
-  [{start :start c :chan blur :blur} input-el ac-el]
-  (let [ac (chan)
-        [c' c'' c'''] (multiplex c 3)
-        no-input      (no-input c' input-el)
-        delay         (after-last c'' 300)
-        interval      (throttle c''' 500)
-        fetch         (debounce (fan-in [delay interval]) 500)]
-    (go
-      (<! start)
-      (loop []
-        (let [[v sc] (alts! [blur no-input fetch])]
-          (condp contains? sc
-            #{no-input blur}
-            (do (set-class ac-el "hidden")
-              (>! ac (.-value input-el))
-              (<! start)
-              (recur))
+(def input-el (by-id "input"))
+(def comp-el (by-id "completions"))
 
-            #{fetch}
-            (let [r (<! (jsonp-chan (str base-url (.-value input-el))))]
-              (show-results r)
-              (recur))))))
-    ac))
+(def channel (->> (:chan (event-chan input-el "keydown"))
+                  (map-chan (fn [_] (.trim (.-value input-el))))
+                  (uniq-chan)
+                  (throt 750)
+                  (monitor "throttle")
+                  (trans-chan completion-chan)))
 
-(defn autocompleter [input-el ac-el]
-  (let [c (->> (:chan (event-chan input-el "keyup"))
-            (map-chan #(get % "keyCode"))
-            (filter-chan (complement IGNORE))) 
-        [kc kc'] (multiplex c [(chan (dropping-buffer 1)) (chan)])
-        ctrl {:start (chan)
-              :chan kc'
-              :blur (:chan (event-chan input-el "blur"))}
-        ac   (autocompleter* ctrl input-el ac-el)]
-    (go
-      (loop [query nil]
-        (<! kc)
-        (recur
-          (when (and (not= query (.-value input-el))
-                     (pos? (alength (.-value input-el))))
-            (>! (:start ctrl) (now))
-            (<! ac)))))))
-
-(autocompleter
-  (by-id "input")
-  (by-id "completions"))
-
-;; TODO: throttle & after-last should be stoppable, we could pass control
-;;       channel, which must be read from to continue, they can reset
-;;       themselves via this mechanism
-;; TODO: closure tools show that spurious keys like Command
-;;       still trigger network activity
-;; TODO: handle selection
+(go-loop
+ (show-results comp-el (<! channel)))
 

--- a/src/async_test/utils/helpers.cljs
+++ b/src/async_test/utils/helpers.cljs
@@ -81,10 +81,10 @@
   ([type] (event-chan js/window type))
   ([el type] (event-chan (chan (sliding-buffer 1)) el type))
   ([c el type]
-    (let [writer #(put! c %)]
-      (.addEventListener el type writer)
-      {:chan c
-       :unsubscribe #(.removeEventListener el type writer)})))
+     (let [writer #(put! c %)]
+       (.addEventListener el type writer)
+       {:chan c
+        :unsubscribe #(.removeEventListener el type writer)})))
 
 (defn map-chan
   ([f source] (map-chan (chan) f source))
@@ -179,3 +179,54 @@
           (let [[x] (alts! ins)]
             (>! c x))))
     c))
+
+(defn uniq-chan
+  [c]
+  (let [c' (chan)]
+    (go
+     (loop [v ::_initial_ v' (<! c)]
+       (when (not= v v')
+         (>! c' v'))
+       (recur v' (<! c))))
+    c'))
+
+(defn timeout-chan [ms source]
+  (let [c' (chan)]
+    (go
+     (let [t (timeout 500)
+           [cc channel] (alts! [source t])]
+       (if (= t channel)
+         (close! c')
+         (>! c' cc))))
+    c'))
+
+(defn throt [ms c]
+  (let [c' (chan 1)]
+    (go
+     (loop [v1 ::_none_
+            t (timeout ms)]
+       (let [[v ch]
+             (alts! [c t])]
+         (if (= c ch)
+           (recur v t)
+           (do
+             (if (= ::_none_ v1)
+               (>! c' (<! c))
+               (>! c' v1))
+             (recur ::_none_ (timeout ms)))))))
+    c'))
+
+(defn monitor [name source]
+  (let [c' (chan)]
+    (go
+     (loop [v (<! source)]
+       (.log js/console (str name ": " v))
+       (>! c' v)
+       (recur (<! source))))
+    c'))
+
+(defn trans-chan [f source]
+  (let [c' (chan)]
+    (go-loop
+     (>! c' (<! (f (<! source)))))
+    c'))


### PR DESCRIPTION
This implementation contains different logic but uses a series of channel transformations instead of a large function with channel logic mixed with autocomplete logic.

I am sending this pull request because I don't know of a better way to send you a diff. No need to accept.
